### PR TITLE
Add generic matrix multiplication kernels

### DIFF
--- a/npbench/infrastructure/triton_utilities.py
+++ b/npbench/infrastructure/triton_utilities.py
@@ -84,12 +84,14 @@ def matmul_float64(a: torch.Tensor, b: torch.Tensor):
 
 @triton.autotune(
         configs=[
+        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=4,
+                      num_warps=4),
         # triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 8}, num_stages=3,
         #               num_warps=8),
         # triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 32, 'GROUP_SIZE_M': 8}, num_stages=4,
         #               num_warps=4),
-        triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'GROUP_SIZE_M': 8}, num_stages=4,
-                      num_warps=4),
+        # triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'GROUP_SIZE_M': 8}, num_stages=4,
+        #               num_warps=4),
         # triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32, 'GROUP_SIZE_M': 8}, num_stages=4,
         #               num_warps=4),
         # triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32, 'GROUP_SIZE_M': 8}, num_stages=4,


### PR DESCRIPTION
This PR adds generic matrix multiplication kernels for use with Triton.
Since a lot of benchmarks are using matrix multiplication, having reasonable mmm kernels helps us getting started easier.
For now, these kernels are not particularly optimized (the `float32` one was taken verbatim from the official docs, the `float64` one was adapted from the `float32` not to use `tl.dot`).

For now, we can get started with the benchmarks (see `k3mm` branch for examples ).

We could consider implementing a similar generic function for matrix-vector multiplication.
Maybe we could think about gluing together these kernels so we have a chance of being faster than existing implementations without duplicating a ton of code?