### PR TITLE
[infra] print full exceptions with stacktraces

### DIFF
--- a/npbench/infrastructure/test.py
+++ b/npbench/infrastructure/test.py
@@ -1,5 +1,6 @@
 # Copyright 2021 ETH Zurich and the NPBench authors. All rights reserved.
 import time
+import traceback
 
 from npbench.infrastructure import (Benchmark, Framework, timeout_decorator as tout, utilities as util)
 from typing import Any, Callable, Dict, Sequence, Tuple, Optional
@@ -32,7 +33,7 @@ class Test(object):
                                            '__npb_result')
         except Exception as e:
             print("Failed to execute the {} implementation.".format(report_str))
-            print(e)
+            traceback.print_exception(e)
             if not ignore_errors:
                 raise
             return None, None


### PR DESCRIPTION
Triton compiler errors are currently very hard to read as only the source location is printed. This is due to the actual error message being part of a chained exception in the `__cause__` field, which is not printed by the standard string conversion.

This PR changes the print behavior to use Pythons standard exception printing mechanism that provides both a traceback and the message. This could technically also be implemented for just the triton framework, but felt like an overall improvement