### PR TITLE
atax & matrix-vector multiplication

### DIFF
--- a/npbench/benchmarks/polybench/atax/atax_triton.py
+++ b/npbench/benchmarks/polybench/atax/atax_triton.py
@@ -1,63 +1,11 @@
-import itertools
-
 import torch
-import triton
-import triton.language as tl
 
-from npbench.infrastructure.triton_utilities import matmul, get_2d_tile_offsets
-
-def generate_config():
-    return [
-        triton.Config(kwargs={"BLOCK_SIZE_M": m, "BLOCK_SIZE_N": n}, num_warps=w)
-        for m, n, w in itertools.product(
-            [8, 16, 32, 64, 128], [8, 16, 32, 64, 128], [1, 2, 4, 8]
-        )
-        if m != 128 or n != 128
-    ]
-
-@triton.autotune(configs=generate_config(), key=["M", "N"], cache_results=True)
-@triton.jit()
-def _kernel(
-            A,  # (M, N)
-            X,  # (N, ),
-            out,  # (M,),
-            M: tl.constexpr, N: tl.constexpr,
-            BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr
-            ):
-    i = tl.program_id(axis=0)
-    j = tl.program_id(axis=1)
-
-    row = (i * BLOCK_SIZE_M) + tl.arange(0, BLOCK_SIZE_M)
-    column = (j * BLOCK_SIZE_N) + tl.arange(0, BLOCK_SIZE_N)
-
-    a = tl.load(
-        A + N * row[:, None] + column[None, :],
-        mask=(column[None, :] < N) & (row[:, None] < M))
-    x = tl.load(X + column, mask=column < N, other=0.0)
-
-    x_sum = tl.sum(a * x[None, :], axis=1)
-    tl.atomic_add(out + row, x_sum, sem="release")
-
-def _mat_vec_mul(
-            A,  # (M, N)
-            X,  # (N, ),
-            out,  # (M,)
-            ):
-
-    M, N = A.shape
-    
-    grid = lambda meta: (
-        triton.cdiv(M, meta["BLOCK_SIZE_M"]),
-        triton.cdiv(N, meta["BLOCK_SIZE_N"]),
-    )
-
-    _kernel[grid](A, X, out, M, N)
-
+from npbench.infrastructure.triton_utilities import mat_vec_mul
 
 def kernel(A: torch.Tensor, x: torch.Tensor):
     Ax = torch.zeros((A.shape[0],), dtype=A.dtype)
-    _mat_vec_mul(A, x, Ax)
+    mat_vec_mul(A, x, Ax)
     A_T = A.t().contiguous()
     res = torch.zeros((A.shape[1],), dtype=A.dtype)
-    _mat_vec_mul(A_T, Ax, res)
+    mat_vec_mul(A_T, Ax, res)
     return res

--- a/npbench/infrastructure/triton_utilities.py
+++ b/npbench/infrastructure/triton_utilities.py
@@ -6,6 +6,8 @@ it is significantly slower.
 Neither of the kernels were tuned specifically. The auto-tuning options are
 currently commented out for faster development.
 """
+import itertools
+
 import torch
 import triton
 import triton.language as tl
@@ -288,3 +290,58 @@ def matmul(a: torch.Tensor, b: torch.Tensor):
         return matmul_float32(a, b)
     else:
         raise NotImplementedError("only float32 and float64 are supported in matmul")
+
+
+def generate_config_mat_vec_mul():
+    return [
+        triton.Config(kwargs={"BLOCK_SIZE_M": m, "BLOCK_SIZE_N": n}, num_warps=w)
+        for m, n, w in itertools.product(
+            [8, 16, 32, 64, 128], [8, 16, 32, 64, 128], [1, 2, 4, 8]
+        )
+        if m != 128 or n != 128
+    ]
+
+@triton.autotune(configs=generate_config_mat_vec_mul(), key=["M", "N"], cache_results=True)
+@triton.jit()
+def mat_vec_mul_kernel(
+            A,  # (M, N)
+            X,  # (N,)
+            out,  # (M,)
+            M: tl.constexpr, N: tl.constexpr,
+            BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr
+            ):
+    i = tl.program_id(axis=0)
+    j = tl.program_id(axis=1)
+
+    tile, mask, row, column = get_2d_tile_offsets(
+        x=j * BLOCK_SIZE_N,
+        y=i * BLOCK_SIZE_M,
+        tile_width=BLOCK_SIZE_N,
+        tile_height=BLOCK_SIZE_M,
+        matrix_width=N,
+        matrix_height=M,
+    )
+    a = tl.load(A + tile, mask)
+    x = tl.load(X + column, mask=column < N, other=0.0)
+
+    x_sum = tl.sum(a * x[None, :], axis=1)
+    tl.atomic_add(out + row, x_sum, sem="release")
+
+def mat_vec_mul(
+            A,  # (M, N)
+            X,  # (N,)
+            out,  # (M,)
+            ):
+    """
+    Performs matrix-vector multiplication between matrix A (M, N) and vector X (N,)
+    Result is written to vector out (M,)
+    """
+
+    M, N = A.shape
+    
+    grid = lambda meta: (
+        triton.cdiv(M, meta["BLOCK_SIZE_M"]),
+        triton.cdiv(N, meta["BLOCK_SIZE_N"]),
+    )
+
+    mat_vec_mul_kernel[grid](A, X, out, M, N)


### PR DESCRIPTION
Implements Triton kernel for Atax

Performance numbers:
```
python3 run_benchmark.py -b atax -f triton -p paper -v True
***** Testing Triton with atax on the paper dataset, datatype default *****
NumPy - default - validation: 255ms
Triton - default - first/validation: 444ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 181ms
```


```
python3 run_benchmark.py -b atax -f dace_gpu -p paper
***** Testing DaCe GPU with atax on the paper dataset, datatype default *****
NumPy - default - validation: 254ms
DaCe GPU - fusion - first/validation: 87ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 60ms
DaCe GPU - parallel - first/validation: 61ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 60ms
DaCe GPU - auto_opt - first/validation: 60ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 60ms
```