### PR TITLE
Add k3mm kernel

### DIFF
--- a/npbench/benchmarks/polybench/k3mm/k3mm_triton.py
+++ b/npbench/benchmarks/polybench/k3mm/k3mm_triton.py
@@ -1,0 +1,7 @@
+import torch
+from npbench.infrastructure.triton_utilities import matmul
+
+def kernel(A: torch.Tensor, B: torch.Tensor, C: torch.Tensor, D: torch.Tensor):
+    E = matmul(A, B)
+    F = matmul(E, C)
+    return matmul(F, D)


### PR DESCRIPTION
## float32 results: Triton

Uncommenting all autotuning options, I get

```
$ python3 run_benchmark.py -b k3mm -f triton -p M -v True -d float32
***** Testing Triton with k3mm on the M dataset, datatype float32 *****
NumPy - default - validation: 144ms
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 98304, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 32, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 32, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 2, num_ctas: 1, num_stages: 5, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 32, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 2, num_ctas: 1, num_stages: 5, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 196608, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 256, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 196608, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 256, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 163840, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 163840, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 131072, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 32, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Triton autotuning for function matmul_kernel_float32,
with key as (2000, 2200, 2400, 'torch.float32', 'torch.float32', 'torch.float32'),
finished after 66.67s,
best config selected: BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None;
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 98304, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 32, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 32, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 2, num_ctas: 1, num_stages: 5, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 32, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 2, num_ctas: 1, num_stages: 5, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 196608, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 256, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 196608, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 256, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 163840, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 163840, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 131072, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 32, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Triton autotuning for function matmul_kernel_float32,
with key as (2000, 2800, 2200, 'torch.float32', 'torch.float32', 'torch.float32'),
finished after 49.33s,
best config selected: BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None;
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 98304, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 32, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 32, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 2, num_ctas: 1, num_stages: 5, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 32, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 2, num_ctas: 1, num_stages: 5, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 196608, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 256, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 8, num_ctas: 1, num_stages: 3, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 196608, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 256, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 163840, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 256, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 163840, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 128, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning failed with out of resource: shared memory, Required: 131072, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 64, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 64, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Autotuning kernel matmul_kernel_float32 with config BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 32, BLOCK_SIZE_K: 64, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None
Triton autotuning for function matmul_kernel_float32,
with key as (2000, 2600, 2800, 'torch.float32', 'torch.float32', 'torch.float32'),
finished after 2.29s,
best config selected: BLOCK_SIZE_M: 128, BLOCK_SIZE_N: 128, BLOCK_SIZE_K: 32, GROUP_SIZE_M: 8, num_warps: 4, num_ctas: 1, num_stages: 4, maxnreg: None;
Triton - default - first/validation: 118513ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 19ms
```

## results: Dace GPU

Note that for this test, I adapted `float64` to `float32` in `/home/rwohlbold/npbench/npbench/benchmarks/polybench/k3mm/k3mm_dace.py`:

```
$ python3 run_benchmark.py -b k3mm -f dace_gpu -p M -v True -d float32
***** Testing DaCe GPU with k3mm on the M dataset, datatype float32 *****
NumPy - default - validation: 142ms
DaCe GPU - fusion - first/validation: 29ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 12ms
DaCe GPU - parallel - first/validation: 12ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 10ms
DaCe GPU - auto_opt - first/validation: 11ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 9ms
```

Is there something we can do about performance here? We have a 2x slowdown over DaCE here

