### PR TITLE
implementation of `gemm` kernel 

### DIFF
--- a/npbench/benchmarks/polybench/gemm/gemm_triton.py
+++ b/npbench/benchmarks/polybench/gemm/gemm_triton.py
@@ -2,6 +2,47 @@ import torch
 import triton
 import triton.language as tl
 
+@triton.autotune(
+    configs=[
+        triton.Config({'BLOCK_M': 64, 'BLOCK_N': 64, 'BLOCK_K': 64}, num_stages=4,
+                      num_warps=4),
+        # triton.Config({'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 64}, num_stages=3,
+        #               num_warps=8),
+        # triton.Config({'BLOCK_M': 64, 'BLOCK_N': 256, 'BLOCK_K': 32}, num_stages=4,
+        #               num_warps=4),
+        # triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 32}, num_stages=4,
+        #               num_warps=4),
+        # triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64, 'BLOCK_K': 32}, num_stages=4,
+        #               num_warps=4),
+        # triton.Config({'BLOCK_M': 64, 'BLOCK_N': 128, 'BLOCK_K': 32}, num_stages=4,
+        #               num_warps=4),
+        # triton.Config({'BLOCK_M': 128, 'BLOCK_N': 32, 'BLOCK_K': 32}, num_stages=4,
+        #               num_warps=4),
+        # triton.Config({'BLOCK_M': 64, 'BLOCK_N': 32, 'BLOCK_K': 32}, num_stages=5,
+        #               num_warps=2),
+        # triton.Config({'BLOCK_M': 32, 'BLOCK_N': 64, 'BLOCK_K': 32}, num_stages=5,
+        #               num_warps=2),
+        # Good config for fp8 inputs.
+        # triton.Config({'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 128}, num_stages=3,
+        #               num_warps=8),
+        # triton.Config({'BLOCK_M': 256, 'BLOCK_N': 128, 'BLOCK_K': 128}, num_stages=3,
+        #               num_warps=8),
+        # triton.Config({'BLOCK_M': 256, 'BLOCK_N': 64, 'BLOCK_K': 128}, num_stages=4,
+        #               num_warps=4),
+        # triton.Config({'BLOCK_M': 64, 'BLOCK_N': 256, 'BLOCK_K': 128}, num_stages=4,
+        #               num_warps=4),
+        # triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 128}, num_stages=4,
+        #               num_warps=4),
+        # triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64, 'BLOCK_K': 64}, num_stages=4,
+        #               num_warps=4),
+        # triton.Config({'BLOCK_M': 64, 'BLOCK_N': 128, 'BLOCK_K': 64}, num_stages=4,
+        #               num_warps=4),
+        # triton.Config({'BLOCK_M': 128, 'BLOCK_N': 32, 'BLOCK_K': 64}, num_stages=4,
+        #               num_warps=4)
+    ],
+    key=["M", "N", "K"]
+)
+
 @triton.jit
 def _kernel(alpha, beta, C_ptr, A_ptr, B_ptr, 
             M, N, K, 
@@ -114,5 +155,4 @@ def kernel(alpha, beta, C: torch.Tensor, A: torch.Tensor, B: torch.Tensor):
                   stride_am, stride_ak, 
                   stride_bk, stride_bn, 
                   stride_cm, stride_cn, 
-                  BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K, 
                   DTYPE=DTYPE, ACC=ACC)


### PR DESCRIPTION
This PR implements the gemm kernel. I'm sorry @josh-freeman (I know this was your kernel to implement), but while I was implementing cholesky (blocked version), I realized I had accidentally implemented gemm (where my alpha and beta were fixed values) so I decided I might as well just generalize my implementation. Hope that's okay!

Performance below:

```
python3 npbench/run_benchmark.py -b gemm -f triton -p paper -v True
***** Testing Triton with gemm on the paper dataset, datatype default *****
NumPy - default - validation: 119ms
Triton - default - first/validation: 254ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 18ms


python3 npbench/run_benchmark.py -b gemm -f dace_gpu -p paper -v True
***** Testing DaCe GPU with gemm on the paper dataset, datatype default *****
NumPy - default - validation: 118ms
DaCe GPU - fusion - first/validation: 121ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 85ms
DaCe GPU - parallel - first/validation: 85ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 85ms
DaCe GPU - auto_opt - first/validation: 84ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 83ms
```