### PR TITLE
implementation of `jacobi_2d` kernel 

### DIFF
--- a/npbench/benchmarks/polybench/jacobi_2d/jacobi_2d_triton.py
+++ b/npbench/benchmarks/polybench/jacobi_2d/jacobi_2d_triton.py
@@ -23,9 +23,6 @@ def jacobi2d_step(src_ptr, dst_ptr,
     pid_x = tl.program_id(0)  # tiles along rows (i)
     pid_y = tl.program_id(1)  # tiles along cols (j)
 
-    num_x = tl.num_programs(axis=0)
-    num_y = tl.num_programs(axis=1)
-
     # Compute global indices of the block
     ii = pid_x * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)[:, None]   # (BLOCK, 1) - row vector
     jj = pid_y * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)[None, :]   # (1, BLOCK) - col vector


### PR DESCRIPTION
Implemented jacobi_2d kernel. Tried to run the dace benchmark and it took ages and got super weird results (it didn't validate..?).

```
***** Testing DaCe GPU with jacobi_2d on the paper dataset, datatype default *****
NumPy - default - validation: 117472ms
DaCe GPU - fusion - first/validation: 375ms
Relative error: 0.0004008499995815878
Relative error: 0.00040085777545066707
DaCe GPU - fusion did not validate!
DaCe GPU - fusion - median: 676ms
DaCe GPU - parallel - first/validation: 675ms
Relative error: 0.00040011460670356686
Relative error: 0.0003988368355837702
DaCe GPU - parallel did not validate!
DaCe GPU - parallel - median: 678ms
DaCe GPU - auto_opt - first/validation: 678ms
Relative error: 0.0003756138838871313
Relative error: 0.00037460472551495964
DaCe GPU - auto_opt did not validate!
DaCe GPU - auto_opt - median: 675ms
```


```
python3 npbench/run_benchmark.py -b jacobi_2d -f triton -p paper -v True
** Testing Triton with jacobi_2d on the paper dataset, datatype default **
NumPy - default - validation: 107005ms
Triton - default - first/validation: 10946ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 4736ms
```