### PR TITLE
[npbench] Implement `bicg` kernel in Triton

### DIFF
--- a/npbench/benchmarks/polybench/bicg/bicg_triton.py
+++ b/npbench/benchmarks/polybench/bicg/bicg_triton.py
@@ -4,78 +4,43 @@ import torch
 import triton
 import triton.language as tl
 
-
-def generate_config0():
+def generate_config():
     return [
-        triton.Config(kwargs={"BLOCK_SIZE_N": b, "BLOCK_SIZE_K": k}, num_warps=w)
-        for b, k, w in itertools.product(
+        triton.Config(kwargs={"BLOCK_SIZE_M": m, "BLOCK_SIZE_N": n}, num_warps=w)
+        for m, n, w in itertools.product(
             [8, 16, 32, 64, 128], [8, 16, 32, 64, 128], [1, 2, 4, 8]
         )
-        if b != 128 or k != 128
+        if m != 128 or n != 128
     ]
 
-
-@triton.autotune(configs=generate_config0(), key=["K", "N"], cache_results=True)
+@triton.autotune(configs=generate_config(), key=["M", "N"], cache_results=True)
 @triton.jit()
-def _kernel0(
-    A,  # (K, N)
-    X,  # (K, ),
-    out,  # (N, ),
-    K: tl.constexpr,
-    N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-):
-    i = tl.program_id(axis=0)
-    j = tl.program_id(axis=1)
-
-    row = (i * BLOCK_SIZE_K) + tl.arange(0, BLOCK_SIZE_K)
-    column = (j * BLOCK_SIZE_N) + tl.arange(0, BLOCK_SIZE_N)
-    a = tl.load(
-        A + N * row[:, None] + column[None, :],
-        mask=(column[None, :] < N) & (row[:, None] < K),
-    )
-    X = tl.load(X + row, mask=row < K, other=0.0)
-
-    # Perform the reduction of the K dimension. A vector corresponding to an N tile remains.
-    a_sum = tl.sum(a * X[:, None], axis=0)
-    tl.atomic_add(out + column, a_sum, sem="release")
-
-
-def generate_config1():
-    return [
-        triton.Config(kwargs={"BLOCK_SIZE_M": b, "BLOCK_SIZE_K": k}, num_warps=w)
-        for b, k, w in itertools.product([8, 16, 32, 64, 128], [8, 16, 32, 64, 128], [1, 2, 4, 8])
-        if b != 128 or k != 128
-    ]
-
-
-@triton.autotune(configs=generate_config1(), key=["M", "K"], cache_results=True)
-@triton.jit()
-def _kernel1(
-    A,  # (M, K)
-    X,  # (K, ),
-    out,  # (M, ),
-    M: tl.constexpr,
-    K: tl.constexpr,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-):
-    zero = tl.zeros((BLOCK_SIZE_K,), out.dtype.element_ty)
+def _kernel(
+        A, # (M, N)
+        R, # (M, )
+        P, # (N, )
+        OUT0, # (M, )
+        OUT1, # (N, )
+        M: tl.constexpr,
+        N: tl.constexpr,
+        BLOCK_SIZE_M: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+    ):
     i = tl.program_id(axis=0)
     j = tl.program_id(axis=1)
 
     row = (i * BLOCK_SIZE_M) + tl.arange(0, BLOCK_SIZE_M)
-    column = (j * BLOCK_SIZE_K) + tl.arange(0, BLOCK_SIZE_K)
+    column = (j * BLOCK_SIZE_N) + tl.arange(0, BLOCK_SIZE_N)
     a = tl.load(
-        A + K * row[:, None] + column[None, :],
-        (column[None, :] < K) & (row[:, None] < M),
-    )
-    X = tl.load(X + column, mask=column < K, other=zero)
+        A + N * row[:, None] + column[None, :],
+        mask=(column[None, :] < N) & (row[:, None] < M))
+    r = tl.load(R + row, mask=row < M, other=0.0)
+    p = tl.load(P + column, mask=column < N, other=0.0)
 
-    # Perform the reduction of the K dimension. A vector corresponding to an M tile remains.
-    a_sum = tl.sum(a * X[None, :], axis=1)
-    tl.atomic_add(out + row, a_sum, sem="release")
+    r_sum = tl.sum(a * r[:, None], axis=0)
+    p_sum = tl.sum(a * p[None, :], axis=1)
+    tl.atomic_add(OUT0 + column, r_sum, sem="release")
+    tl.atomic_add(OUT1 + row, p_sum, sem="release")
 
 
 def kernel(A: torch.Tensor, p: torch.Tensor, r: torch.Tensor):
@@ -83,14 +48,9 @@ def kernel(A: torch.Tensor, p: torch.Tensor, r: torch.Tensor):
     out0 = torch.zeros((A.shape[1],), dtype=A.dtype)
     out1 = torch.zeros((A.shape[0],), dtype=A.dtype)
 
-    grid0 = lambda meta: (
-        triton.cdiv(A.shape[0], meta["BLOCK_SIZE_K"]),
+    grid = lambda meta: (
+        triton.cdiv(A.shape[0], meta["BLOCK_SIZE_M"]),
         triton.cdiv(A.shape[1], meta["BLOCK_SIZE_N"]),
     )
-    grid1 = lambda meta: (
-        triton.cdiv(A.shape[0], meta["BLOCK_SIZE_M"]),
-        triton.cdiv(A.shape[1], meta["BLOCK_SIZE_K"]),
-    )
-    _kernel0[grid0](A, r, out0, A.shape[0], A.shape[1])
-    _kernel1[grid1](A, p, out1, A.shape[0], A.shape[1])
+    _kernel[grid](A, r, p, out0, out1, A.shape[0], A.shape[1])
     return out0, out1


### PR DESCRIPTION
This PR implements the `bicg` kernel, which is just two matrix-vector multiplications, like `r @ A, A @ p`. We fuse those together to limit data movement. The implementation of the matrix-vector multiplications was inspired by the `gesummv` kernel implementation by @zero9178 (#14).

This way, we achieve a ~40% speedup over DaCe (before, with two unfused kernels, the run times were approximately the same).

```
$ python3 run_benchmark.py -b bicg -f triton -p L -v True
***** Testing Triton with bicg on the L dataset, datatype default *****
NumPy - default - validation: 309ms
[...]
best config selected: BLOCK_SIZE_M: 16, BLOCK_SIZE_N: 128, num_warps: 1, num_ctas: 1, num_stages: 3, maxnreg: None;
Triton - default - first/validation: 47539ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 12ms
```

```
$ python3 run_benchmark.py -b bicg -f dace_gpu -p L -v True
***** Testing DaCe GPU with bicg on the L dataset, datatype default *****
NumPy - default - validation: 314ms
DaCe GPU - fusion - first/validation: 36ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 20ms
DaCe GPU - parallel - first/validation: 21ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 20ms
DaCe GPU - auto_opt - first/validation: 21ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 20ms
``` 