### PR TITLE
implemenation of `gemver` kernel

### DIFF
--- a/npbench/benchmarks/polybench/gemver/gemver_triton.py
+++ b/npbench/benchmarks/polybench/gemver/gemver_triton.py
@@ -121,8 +121,9 @@ def kernel(alpha, beta, A: torch.Tensor, u1, v1, u2, v2, w, x, y, z):
     # x += beta * y @ A + z
     x_out = x.new_zeros(N)
     compute_x_kernel[grid_1d](beta, A, y, z, x, x_out, N, DTYPE=DTYPE)
-    torch.cuda.synchronize()
     x.copy_(x_out)
-
+    
     # w += alpha * A @ x
-    compute_w_kernel[grid_1d](alpha, A, x_out, w, N, DTYPE=DTYPE)
+    compute_w_kernel[grid_1d](alpha, A, x, w, N, DTYPE=DTYPE)
+    
+   


### PR DESCRIPTION
This PR adds a Triton implementation of the GEMVER benchmark.

The computation follows the reference NumPy version:
```
    A += np.outer(u1, v1) + np.outer(u2, v2)
    x += beta * y @ A + z
    w += alpha * A @ x
```
The computation is decomposed into three Triton kernels, one per statement:
compute_A_kernel — updates A via two outer products.
compute_x_kernel — computes x += β * y @ A + z.
compute_w_kernel — computes w += α * A @ x.

This split was chosen due to data dependencies between stages (A → x → w), which make in-kernel synchronization non-trivial. Not sure if we want to address this in future (we can discuss tomorrow).

Performance: we SMASHHHHHH numpy, and are a couple ms faster than DACE. 

```
python3 npbench/run_benchmark.py -b gemver -f dace_gpu -p paper -v True
***** Testing DaCe GPU with gemver on the paper dataset, datatype default *****
NumPy - default - validation: 442ms
DaCe GPU - fusion - first/validation: 48ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 26ms
DaCe GPU - parallel - first/validation: 33ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 26ms
DaCe GPU - auto_opt - first/validation: 30ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 26ms

python3 npbench/run_benchmark.py -b gemver -f triton -p paper -v True
***** Testing Triton with gemver on the paper dataset, datatype default *****
NumPy - default - validation: 445ms
Triton - default - first/validation: 286ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 20ms
```