### PR TITLE
implemenation of `syr2k` kernel 

### DIFF
--- a/npbench/benchmarks/polybench/syr2k/syr2k_triton.py
+++ b/npbench/benchmarks/polybench/syr2k/syr2k_triton.py
@@ -1,0 +1,99 @@
+import itertools
+
+import triton
+import triton.language as tl
+
+from npbench.infrastructure.triton_utilities import get_1d_tile_offsets
+
+
+def generate_config():
+    """
+    Generates many config instances for the purpose of auto-tuning.
+    'num_warps' is especially useful for performance when reduction is involved as it may enable or disable certain
+    cross-warp optimizations.
+    """
+    return [triton.Config(kwargs={'BLOCK_SIZE': b}, num_warps=w) for b, w in
+            itertools.product([16, 32, 64, 256, 512, 1024], [1, 2, 4, 8, 16, 32])]
+
+
+@triton.autotune(configs=generate_config(),
+                 key=['N', 'M'],
+                 cache_results=True
+                 )
+@triton.jit()
+def _kernel(alpha, beta,
+            C,  # (N, N)
+            A,  # (N, M)
+            B, # (N, M)
+            BLOCK_SIZE: tl.constexpr, N: tl.constexpr, M: tl.constexpr):
+    i = tl.program_id(axis=0)
+    j = tl.program_id(axis=1)
+    if j >= i + 1:
+        return
+
+    c_ptr = C + i * N + j 
+
+    # Perform a parallel reduction over A[i, k] and A[j, k] simultaneously.
+    # The parallelism is introduced similarly as we did in ASL:
+    # 'BLOCK_SIZE' many accumulators are used that we sum up at the end.
+    s = tl.zeros((BLOCK_SIZE,), c_ptr.dtype.element_ty)
+    for k in range(tl.cdiv(M, BLOCK_SIZE)):
+        tile, mask = get_1d_tile_offsets(k * BLOCK_SIZE, BLOCK_SIZE, M)
+
+        # A[j, k:k+BLOCK_SIZE]
+        a_tensor = tl.load(A + j * M + tile, mask=mask)
+        
+        # B[i, k:k+BLOCK_SIZE]
+        b_diag = tl.load(B + i * M + tile, mask=mask)
+        s += alpha * a_tensor * b_diag
+
+        # B[j, k:k+BLOCK_SIZE]
+        b_tensor = tl.load(B + j * M + tile, mask=mask)
+
+        # B[i, k:k+BLOCK_SIZE]
+        a_diag = tl.load(A + i * M + tile, mask=mask)
+        s += alpha * b_tensor * a_diag
+
+    # Sum up the entire tensor into a single scalar.
+    s = tl.sum(s)
+
+    c_elem = tl.load(c_ptr)
+    c_elem *= beta
+    c_elem += s
+    tl.store(c_ptr, c_elem)
+
+
+def kernel(alpha, beta, C, A, B):
+    """
+    Implements a restructured form of the kernel:
+
+    for i in range(A.shape[0]):
+        C[i, :i + 1] *= beta
+        for k in range(A.shape[1]):
+            C[i, :i + 1] += (A[:i + 1, k] * alpha * B[i, k] +
+                             B[:i + 1, k] * alpha * A[i, k])
+                             
+    that is implemented as:
+
+    for i in range(A.shape[0]):
+        for j in range(i + 1):
+            C[i, j] *= beta
+
+        for j in range(i + 1):
+            s = 0
+            for k in range(A.shape[1]):
+                s += alpha * A[j, k] * B[i, k] 
+                s += alpha * B[j, k] * A[j, k]
+
+            C[i, j] += s
+
+
+    We perform the grid parallelization across the 'i' and 'j' loops and perform tiling over the 'k' loop for parallel
+    reduction.
+    The latter enables an optimization in the GPU where a single warp (ie 32 threads!) are scheduled to implement
+    the reduction and finally perform a warp-level reduction instruction. This theoretically provides full utilization
+    of the SM and parallelism across the grid.
+    """
+
+    N = A.shape[0]
+    _kernel[(N, N)](alpha, beta, C, A, B, N=N, M=A.shape[1])


### PR DESCRIPTION
Implemented `syr2k` kernel --> it is super close to the `syrk` kernel @zero9178 implemented, so I give him the credit because I only had to add a few extra lines.  

![image](https://github.com/user-attachments/assets/353db41b-6a4d-4a0d-902c-16442679f537)
![image](https://github.com/user-attachments/assets/c96ae88e-dbf8-4d9f-a78a-8c3d58be0b22)


Performance Results: Dace timed out :( but we SMASSHHHEED NUMPY
```
 python3 npbench/run_benchmark.py -b syr2k -f dace_gpu -p paper -v True
***** Testing DaCe GPU with syr2k on the paper dataset, datatype default *****
NumPy - default - validation: 11104ms
first_execution took too long

python3 npbench/run_benchmark.py -b syr2k -f triton -p paper -v True
***** Testing Triton with syr2k on the paper dataset, datatype default *****
NumPy - default - validation: 11123ms
Triton - default - first/validation: 161379ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 93ms
```