### PR TITLE
implemenation of `trisolv` kernel

### DIFF
--- a/npbench/benchmarks/polybench/trisolv/trisolv_triton.py
+++ b/npbench/benchmarks/polybench/trisolv/trisolv_triton.py
@@ -5,18 +5,12 @@ import itertools
 from npbench.infrastructure.triton_utilities import get_1d_tile_offsets
 
 def generate_config():
-    base = [
-        (32,   1, 2),
-        (64,   2, 2),
-        (64,   4, 3),
-        (128,  4, 3),
-        (128,  8, 4),
-        (256,  8, 4),
+    return [
+        triton.Config(kwargs={"BLOCK_SIZE_K": k}, num_warps=w)
+        for k, w in itertools.product(
+            [512, 1024, 2048, 4096, 8192, 16384], [1, 2, 4, 8]
+        )
     ]
-    return [triton.Config(
-                kwargs={"BLOCK_SIZE_K": k},
-                num_warps=w, num_stages=s)
-            for (k, w, s) in base]
 
 @triton.autotune(configs=generate_config(), key=["N"], cache_results=True)
 @triton.jit


### PR DESCRIPTION
Implemented trisolv kernel. I blocked the inner loop:

    #     for i in range(N):
    #         s = 0.0
    #         for j in range(i):
    #             s += L[i, j] * x[j]
    #         x[i] = (b[i] - s) / L[i, I]


![image](https://github.com/user-attachments/assets/ec3fd18c-65aa-4005-b4dc-fbe17cec1f37)

```
python3 npbench/run_benchmark.py -b trisolv -f dace_gpu -p paper -v True
***** Testing DaCe GPU with trisolv on the paper dataset, datatype default *****
NumPy - default - validation: 114ms
DaCe GPU - fusion - first/validation: 72707ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 72676ms
DaCe GPU - parallel - first/validation: 72739ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 72735ms
DaCe GPU - auto_opt - first/validation: 72668ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 72665ms

python3 npbench/run_benchmark.py -b trisolv -f triton -p paper -v True
***** Testing Triton with trisolv on the paper dataset, datatype default *****
NumPy - default - validation: 92ms
Triton - default - first/validation: 46394ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 113
```