### PR TITLE
[npbench] Implement `crc16` kernel in Triton

### DIFF
--- a/npbench/benchmarks/crc16/crc16_triton.py
+++ b/npbench/benchmarks/crc16/crc16_triton.py
@@ -15,7 +15,7 @@ def _kernel(data, N, poly: tl.uint16, out):
             else:
                 crc >>= 1
             cur_byte >>= 1
-    crc = ~crc
+    crc = ~crc 
     crc = (crc << 8) | (crc >> 8)
     tl.store(out, crc)
 


### PR DESCRIPTION
This PR implements the `crc16` kernel in Triton. There are two implementations: a naive one as well as one based on lookup tables.
The main CRC algorithm is sequential, which we port over to Triton (which already yields a substantial speedup). The improved algorithm first computed a lookup table, so it can work without any branching.

## Benchmarks - Lookup Table Algorithm

### Lookup Table Algorithm

```
$ python3 run_benchmark.py -b crc16 -f triton -p L -v True
***** Testing Triton with crc16 on the L dataset, datatype default *****
NumPy - default - validation: 547ms
Triton - default - first/validation: 239ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 7ms
```

### Naive Algorithm

```
$ python3 run_benchmark.py -b crc16 -f triton -p L -v True
***** Testing Triton with crc16 on the L dataset, datatype default *****
NumPy - default - validation: 533ms
Triton - default - first/validation: 248ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 17ms
```

### DaCe GPU

```
$ python3 run_benchmark.py -b crc16 -f dace_gpu -p L -v True
***** Testing DaCe GPU with crc16 on the L dataset, datatype default *****
NumPy - default - validation: 542ms
DaCe GPU - fusion - first/validation: 4581ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 4476ms
DaCe GPU - parallel - first/validation: 4478ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 4486ms
DaCe GPU - auto_opt - first/validation: 4493ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 4489ms
```