### PR TITLE
Implementation of `mlp`

### DIFF
--- a/npbench/benchmarks/deep_learning/mlp/mlp_triton.py
+++ b/npbench/benchmarks/deep_learning/mlp/mlp_triton.py
@@ -51,6 +51,7 @@ def row_addition_relu(
 
     _kernel_row_addition_relu[grid](A, B, N, A.stride(0), A.stride(1))
 
+@triton.jit
 def load_row(
         A_ptr: torch.Tensor,
         B_ptr: torch.Tensor,


### PR DESCRIPTION
Implements Triton kernel for `mlp`

The `initialize` function only supports `np.float32` datatype.

## Performance numbers:

### Triton
```
/usr/bin/python3 /home/aszymkowiak/npbench/run_benchmark.py -b mlp -f triton -p paper -v True 
***** Testing Triton with mlp on the paper dataset, datatype default *****
NumPy - default - validation: 72ms
Triton - default - first/validation: 243ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 9ms
```


### DaCe
```
/usr/bin/python3 /home/aszymkowiak/npbench/run_benchmark.py -b mlp -f dace_gpu -p paper 
***** Testing DaCe GPU with mlp on the paper dataset, datatype default *****
NumPy - default - validation: 72ms
DaCe GPU - fusion - first/validation: 39ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 4ms
DaCe GPU - parallel - first/validation: 6ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 4ms
DaCe GPU - auto_opt - first/validation: 6ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 3ms
```