### PR TITLE
[polybench] implementation of durbin kernel

### DIFF
--- a/npbench/benchmarks/polybench/durbin/durbin_cupy.py
+++ b/npbench/benchmarks/polybench/durbin/durbin_cupy.py
@@ -11,7 +11,7 @@ def kernel(r):
     for k in range(1, r.shape[0]):
         beta *= 1.0 - alpha * alpha
         alpha = -(r[k] + np.dot(np.flip(r[:k]), y[:k])) / beta
-        y[:k] += alpha * np.flip(y[:k]) 
-        y[k] = alpha 
+        y[:k] += alpha * np.flip(y[:k])
+        y[k] = alpha
 
     return y


### PR DESCRIPTION
This PR implements the Durbin benchmark, which solves a Toeplitz system. The way it does this is by iterating with an enormous amount of sequential dependencies. This leads me to the following insight: some benchmarks are inherently incompatible with what Triton is designed for; e.g., Durbin is a loop with a bunch of sequential dependencies and will thus be slower due to the obligatory loads and stores incurred by Triton. See for yourself:

```
/usr/bin/python3 /home/jfreeman/npbench/run_benchmark.py -p L -f triton -b durbin 
***** Testing Triton with durbin on the L dataset, datatype default *****
NumPy - default - validation: 1132ms
Triton - default - first/validation: 4323ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 4041ms
```

addendum:

If this implementation has any advantage, it would only be for very large sizes (bigger than the L dataset)


Note that DaCe is faster because they only parallelize the flipping and leave the rest to automatic optimization.


```
/usr/bin/python3 /home/jfreeman/npbench/run_benchmark.py -p L -f dace_gpu -b durbin 
***** Testing DaCe GPU with durbin on the L dataset, datatype default *****
NumPy - default - validation: 1109ms
DaCe GPU - fusion - first/validation: 807ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 808ms
DaCe GPU - parallel - first/validation: 802ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 797ms
DaCe GPU - auto_opt - first/validation: 734ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 731ms
```