### PR TITLE
[polybench] implementation of mandelbrot1 kernel

### DIFF
--- a/npbench/benchmarks/mandelbrot1/mandelbrot1_triton.py
+++ b/npbench/benchmarks/mandelbrot1/mandelbrot1_triton.py
@@ -8,7 +8,7 @@ def _kernel_mandelbrot(
       N_ptr,          # output: iteration counts
       Z_real_ptr,     # output: real part of Z
       Z_imag_ptr,     # output: imaginary part of Z
-      xmin, xmax, ymin, ymax,  # bounds
+      xmin: tl.float64, xmax: tl.float64, ymin: tl.float64, ymax: tl.float64,  # bounds
       xn, yn,         # grid size
       maxiter,
       horizon,


### PR DESCRIPTION
This kernel implements a rendering of the Mandelbrot set. The original numpy implementation uses the `complex128` data type, which has operations that are mathematically equivalent but not numerically so. This leads me to the following insight: 
Some kernels may not be possible to exactly numerically reproduce in Triton, because of a difference in FP units used/compiler optimizations. For example, Mandelbrot’s numpy implementation uses complex128 numbers on the CPU. No such equivalent exists on Triton; I had to manually do the complex operations on pairs of FP64s. My understanding is that triton is not optimized to be numerically identical to numpy in this case, and so they naturally diverge due to things like the lack of associativity of FP multiplication.


<img width="1500" height="1000" alt="image" src="https://github.com/user-attachments/assets/d3b96c68-3190-4067-a074-a8a9efa69116" />

# Test Plan
```
/usr/bin/python3 /home/jfreeman/npbench/run_benchmark.py -p L -f triton -b mandelbrot1 
***** Testing Triton with mandelbrot1 on the L dataset, datatype default *****
NumPy - default - validation: 607ms
Triton - default - first/validation: 519ms
Relative error: 0.07668758854638695
Relative error: 0.3032480330671912
Triton - default did not validate!
Triton - default - median: 9ms
```

Interestingly, we are not the only ones to not validate:

```
/usr/bin/python3 /home/jfreeman/npbench/run_benchmark.py -p L -f dace_gpu -b mandelbrot1 
***** Testing DaCe GPU with mandelbrot1 on the L dataset, datatype default *****
NumPy - default - validation: 619ms
DaCe GPU - fusion - first/validation: 292ms
Relative error: 0.017429330564799166
Relative error: 0.1303675179177225
DaCe GPU - fusion did not validate!
DaCe GPU - fusion - median: 36ms
DaCe GPU - parallel - first/validation: 38ms
Relative error: 0.017429330564799166
Relative error: 0.1303675179177225
DaCe GPU - parallel did not validate!
DaCe GPU - parallel - median: 36ms
DaCe GPU - auto_opt - first/validation: 32ms
Relative error: 0.017429330564799166
Relative error: 0.1303675179177225
DaCe GPU - auto_opt did not validate!
DaCe GPU - auto_opt - median: 30ms
```

# Annex

Here is the script I used to generate the illustration above:

```python
#!/usr/bin/env python3
import numpy as np
import matplotlib.pyplot as plt
import sys
import os

# Add npbench to path
sys.path.insert(0, os.path.dirname(__file__))

from npbench.benchmarks.mandelbrot1 import mandelbrot1_numpy, mandelbrot1_triton

# Test parameters (small for quick visualization)
xmin, xmax = -2.0, 1.0
ymin, ymax = -1.5, 1.5
xn, yn = 800, 600
maxiter = 50
horizon = 2.0

print("Computing NumPy version...")
Z_numpy, N_numpy = mandelbrot1_numpy.mandelbrot(xmin, xmax, ymin, ymax, xn, yn, maxiter, horizon)

print("Computing Triton version...")
Z_triton, N_triton = mandelbrot1_triton.mandelbrot(xmin, xmax, ymin, ymax, xn, yn, maxiter, horizon)

# Convert to numpy if needed
if hasattr(N_triton, 'cpu'):
    N_triton = N_triton.cpu().numpy()
if hasattr(Z_triton, 'cpu'):
    Z_triton = Z_triton.cpu().numpy()

# Create visualization
fig, axes = plt.subplots(2, 3, figsize=(15, 10))

# Plot iteration counts
axes[0, 0].imshow(N_numpy, cmap='hot', origin='lower')
axes[0, 0].set_title('NumPy - Iteration Count (N)')
axes[0, 0].axis('off')

axes[0, 1].imshow(N_triton, cmap='hot', origin='lower')
axes[0, 1].set_title('Triton - Iteration Count (N)')
axes[0, 1].axis('off')

# Difference in N
diff_N = N_triton - N_numpy
axes[0, 2].imshow(diff_N, cmap='RdBu', origin='lower', vmin=-10, vmax=10)
axes[0, 2].set_title(f'Difference (N)\nMax: {np.max(np.abs(diff_N)):.2f}')
axes[0, 2].axis('off')

# Plot Z magnitudes
axes[1, 0].imshow(np.abs(Z_numpy), cmap='viridis', origin='lower')
axes[1, 0].set_title('NumPy - |Z|')
axes[1, 0].axis('off')

axes[1, 1].imshow(np.abs(Z_triton), cmap='viridis', origin='lower')
axes[1, 1].set_title('Triton - |Z|')
axes[1, 1].axis('off')

# Difference in |Z|
diff_Z = np.abs(Z_triton) - np.abs(Z_numpy)
axes[1, 2].imshow(diff_Z, cmap='RdBu', origin='lower')
axes[1, 2].set_title(f'Difference (|Z|)\nMax: {np.max(np.abs(diff_Z)):.2f}')
axes[1, 2].axis('off')

plt.tight_layout()

# Try to save, but don't fail if path issue
try:
    output_path = os.path.join(os.path.dirname(__file__), 'mandelbrot_comparison.png')
    plt.savefig(output_path, dpi=150)
    print(f"\nVisualization saved to: {output_path}")
except Exception as e:
    print(f"\nCouldn't save image: {e}")
    print("Continuing with statistics...")

# Print statistics
print(f"\nNumPy N range: [{np.min(N_numpy)}, {np.max(N_numpy)}]")
print(f"Triton N range: [{np.min(N_triton)}, {np.max(N_triton)}]")
print(f"N difference max: {np.max(np.abs(diff_N))}")
print(f"N difference mean: {np.mean(np.abs(diff_N))}")
print(f"\nNumPy |Z| range: [{np.min(np.abs(Z_numpy)):.4f}, {np.max(np.abs(Z_numpy)):.4f}]")
print(f"Triton |Z| range: [{np.min(np.abs(Z_triton)):.4f}, {np.max(np.abs(Z_triton)):.4f}]")
print(f"|Z| difference max: {np.max(np.abs(diff_Z)):.4f}")

plt.show()
```