### PR TITLE
Implement `azimint_naive`

### DIFF
--- a/npbench/benchmarks/azimint_naive/azimint_naive_triton.py
+++ b/npbench/benchmarks/azimint_naive/azimint_naive_triton.py
@@ -48,7 +48,7 @@ def triton_max(x: torch.Tensor):
 @triton.jit
 def _accumulate_bins_kernel(data_ptr, radius_ptr,
                             sums_ptr, counts_ptr,
-                            N, n_bins, rmax,
+                            N, n_bins, rmax: tl.float64,
                             BLOCK_SIZE: tl.constexpr):
     # axis 0 = bin index; axis 1 = block id over the data
     bin_idx = tl.program_id(axis=0)


### PR DESCRIPTION
Implements Triton kernel for `azimint_naive`

### Triton
```
/usr/bin/python3 /home/aszymkowiak/npbench/run_benchmark.py -b azimint_naive -f triton -p paper -v True 
***** Testing Triton with azimint_naive on the paper dataset, datatype default *****
NumPy - default - validation: 771ms
Triton - default - first/validation: 12659ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 41ms
```

### DaCe GPU
```
/usr/bin/python3 /home/aszymkowiak/npbench/run_benchmark.py -b azimint_naive -f dace_gpu -p paper 
***** Testing DaCe GPU with azimint_naive on the paper dataset, datatype default *****
NumPy - default - validation: 600ms
DaCe GPU - fusion - first/validation: 100ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 94ms
GPU runtime error at /home/aszymkowiak/npbench/.dacecache/parallel/src/cpu/parallel.cpp:47: an illegal memory access was encountered (700)
GPU runtime error at /home/aszymkowiak/npbench/.dacecache/parallel/src/cpu/parallel.cpp:51: an illegal memory access was encountered (700)
Failed to execute the DaCe GPU - parallel implementation.
Traceback (most recent call last):
...
cupy_backends.cuda.api.driver.CUDADriverError: CUDA_ERROR_ILLEGAL_ADDRESS: an illegal memory access was encountered

Process finished with exit code 139 (interrupted by signal 11:SIGSEGV)
```