### PR TITLE
Implementation of `symm`

### DIFF
--- a/npbench/benchmarks/polybench/symm/symm_triton.py
+++ b/npbench/benchmarks/polybench/symm/symm_triton.py
@@ -6,10 +6,9 @@ import triton.language as tl
 def generate_config():
     ms = [64, 128]
     ns = [64, 128]
-    ks = [16, 32, 64]
-    warps = [2, 4]
+    ks = [32, 64]
     cfgs = []
-    for m, n, k, w in itertools.product(ms, ns, ks, warps):
+    for m, n, k in itertools.product(ms, ns, ks):
         if m == 128 and n == 128 and k == 64:
             pass
         cfgs.append(
@@ -19,7 +18,6 @@ def generate_config():
                     "BLOCK_SIZE_N": n,
                     "BLOCK_SIZE_K": k,
                 },
-                num_warps=w,
             )
         )
     return cfgs


### PR DESCRIPTION
Implements Triton kernel for `symm`

## Performance numbers:

### Triton

```
/usr/bin/python3 /home/aszymkowiak/npbench/run_benchmark.py -b symm -f triton -p paper -v True 
***** Testing Triton with symm on the paper dataset, datatype default *****
NumPy - default - validation: 6077ms
Triton - default - first/validation: 100440ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 107ms
```

### DaCe GPU

```
/usr/bin/python3 /home/aszymkowiak/npbench/run_benchmark.py -b symm -f dace_gpu -p paper 
***** Testing DaCe GPU with symm on the paper dataset, datatype default *****
NumPy - default - validation: 5966ms
DaCe GPU - fusion - first/validation: 27345ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 27212ms
DaCe GPU - parallel - first/validation: 27222ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 27324ms
DaCe GPU - auto_opt - first/validation: 22635ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 22651ms
```