### PR TITLE
implements `covariance2`

### DIFF
--- a/npbench/benchmarks/polybench/covariance2/covariance2_triton.py
+++ b/npbench/benchmarks/polybench/covariance2/covariance2_triton.py
@@ -1,0 +1,81 @@
+import itertools
+import torch
+import triton
+import triton.language as tl
+from npbench.infrastructure.triton_utilities import get_2d_tile_offsets, matmul
+
+def generate_config():
+    return [
+        triton.Config(kwargs={"BLOCK_SIZE_M": m, "BLOCK_SIZE_N": n}, num_warps=w)
+        for m, n, w in itertools.product(
+            [8, 16, 32, 64, 128], [8, 16, 32, 64, 128], [1, 2, 4, 8]
+        )
+        if m != 128 or n != 128
+    ]
+
+@triton.autotune(configs=generate_config(), key=["N", "M"])
+@triton.jit
+def _kernel_mean_cols(
+    data,
+    N, M,
+    out_mean,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+):
+    pid_n = tl.program_id(axis=0)
+    pid_m = tl.program_id(axis=1)
+
+    tile, mask, rows, cols = get_2d_tile_offsets(
+        x=pid_m * BLOCK_SIZE_M,
+        y=pid_n * BLOCK_SIZE_N,
+        tile_width=BLOCK_SIZE_M,
+        tile_height=BLOCK_SIZE_N,
+        matrix_width=M,
+        matrix_height=N,
+    )
+    vals = tl.load(data + tile, mask=mask, other=0.0)
+    partial = tl.sum(vals, axis=0) / N
+    tl.atomic_add(out_mean + cols, partial, mask=cols < M)
+
+@triton.autotune(configs=generate_config(), key=["N", "M"])
+@triton.jit
+def _kernel_center_cols(
+    data, mean,
+    N, M,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+):
+    pid_n = tl.program_id(axis=0)
+    pid_m = tl.program_id(axis=1)
+
+    tile, mask, rows, cols = get_2d_tile_offsets(
+        x=pid_m * BLOCK_SIZE_M,
+        y=pid_n * BLOCK_SIZE_N,
+        tile_width=BLOCK_SIZE_M,
+        tile_height=BLOCK_SIZE_N,
+        matrix_width=M,
+        matrix_height=N,
+    )
+    vals  = tl.load(data + tile, mask=mask, other=0.0)
+    means = tl.load(mean + cols, mask=cols < M, other=0.0)
+    tl.store(data + tile, vals - means, mask=mask)
+
+def kernel(M, float_n, data: torch.Tensor):
+    N = data.shape[0]
+
+    mean = torch.zeros((M,), dtype=data.dtype)
+
+    grid = lambda meta: (
+        triton.cdiv(N, meta["BLOCK_SIZE_N"]),
+        triton.cdiv(M, meta["BLOCK_SIZE_M"]),
+    )
+
+    # 1) column means
+    _kernel_mean_cols[grid](data, N, M, mean)
+
+    # 2) center in-place
+    _kernel_center_cols[grid](data, mean, N, M)
+
+    # 3) covariance over variables (columns) with N-1 denominator
+    cov = matmul(data.T, data) / (float(float_n) - 1.0)
+    return cov


### PR DESCRIPTION
Implements Triton kernel for `covariance2`.

Basically, copy-paste from `covariance`- even the same execution time.

## Performance numbers:

### Triton

```
/usr/bin/python3 /home/aszymkowiak/npbench/run_benchmark.py -b covariance2 -f triton -p paper -v True 
***** Testing Triton with covariance2 on the paper dataset, datatype default *****
NumPy - default - validation: 19ms
Triton - default - first/validation: 21019ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 51ms
```

### DaCe GPU

**NOT IMPLEMENTED**