### PR TITLE
Implementation of `nussinov`

### DIFF
--- a/npbench/benchmarks/polybench/nussinov/nussinov_triton.py
+++ b/npbench/benchmarks/polybench/nussinov/nussinov_triton.py
@@ -1,0 +1,65 @@
+import torch
+import triton
+import triton.language as tl
+
+# One kernel computes all cells on a single anti-diagonal j - i == d
+@triton.jit
+def nussinov_diagonal_kernel(table_ptr, stride_tm, stride_tn,
+                             seq_ptr,
+                             N, d: tl.constexpr):
+    pid = tl.program_id(0)   # index along this diagonal
+    i = pid
+    j = i + d
+
+    # guard
+    if (i < 0) | (j >= N):
+        return
+
+    # best = 0
+    best = tl.zeros((), dtype=tl.int32)
+
+    # left: table[i, j-1]
+    if j - 1 >= 0:
+        best = tl.maximum(best, tl.load(table_ptr + i * stride_tm + (j - 1) * stride_tn))
+
+    # down: table[i+1, j]
+    if i + 1 < N:
+        best = tl.maximum(best, tl.load(table_ptr + (i + 1) * stride_tm + j * stride_tn))
+
+    # diag: table[i+1, j-1] (+ match if i < j-1)
+    if (i + 1 < N) & (j - 1 >= 0):
+        tdiag = tl.load(table_ptr + (i + 1) * stride_tm + (j - 1) * stride_tn)
+        if i < j - 1:
+            si = tl.load(seq_ptr + i)
+            sj = tl.load(seq_ptr + j)
+            matched = tl.where(si + sj == 3, 1, 0)
+            tdiag = tdiag + matched
+        best = tl.maximum(best, tdiag)
+
+    # split: max over k in (i+1 .. j-1) of table[i,k] + table[k+1, j]
+    k = i + 1
+    while k < j:
+        left  = tl.load(table_ptr + i * stride_tm + k * stride_tn)
+        right = tl.load(table_ptr + (k + 1) * stride_tm + j * stride_tn)
+        best = tl.maximum(best, left + right)
+        k += 1
+
+    # store result
+    tl.store(table_ptr + i * stride_tm + j * stride_tn, best)
+
+
+def kernel(N: int, seq: torch.Tensor):
+    table = torch.zeros((N, N), dtype=seq.dtype)
+
+    stride_tm, stride_tn = table.stride()
+
+    # sweep anti-diagonals d = 1..N-1
+    for d in range(1, N):
+        n_cells = N - d  # number of (i, j=i+d) positions
+        nussinov_diagonal_kernel[(n_cells,)](
+            table, stride_tm, stride_tn,
+            seq,
+            N, d,
+        )
+
+    return table


### PR DESCRIPTION
Implements Triton kernel for `nussinov`

## Performance numbers:

### Triton

```
/usr/bin/python3 /home/aszymkowiak/npbench/run_benchmark.py -b nussinov -f triton -p paper -v True 
***** Testing Triton with nussinov on the paper dataset, datatype default *****
NumPy - default - validation: 12050ms
Triton - default - first/validation: 652ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 14ms
```

### DaCe GPU

Timeout

```
/usr/bin/python3 /home/aszymkowiak/npbench/run_benchmark.py -b nussinov -f dace_gpu -p paper 
***** Testing DaCe GPU with nussinov on the paper dataset, datatype default *****
NumPy - default - validation: 12214ms
first_execution took too long

Doesn't seem to finish??
```