### PR TITLE
Implement `mandelbrot2` kernel in Triton

### DIFF
--- a/npbench/benchmarks/mandelbrot1/mandelbrot1_triton.py
+++ b/npbench/benchmarks/mandelbrot1/mandelbrot1_triton.py
@@ -2,7 +2,16 @@ import numpy as np
 import torch
 import triton
 import triton.language as tl
+import itertools
 
+def get_configs():
+    return [
+        triton.Config(
+            {"BLOCK_SIZE_X": bx, "BLOCK_SIZE_Y": by}, num_warps=w
+        ) for bx, by, w in itertools.product([4, 8, 16, 32], [4, 8, 16], [1, 2, 4, 8])
+    ]
+
+@triton.autotune(configs=get_configs(), key=["xn", "yn", "maxiter"])
 @triton.jit
 def _kernel_mandelbrot(
       N_ptr,          # output: iteration counts
@@ -63,9 +72,10 @@ def mandelbrot(xmin, xmax, ymin, ymax, xn, yn, maxiter, horizon=2.0):
     Z_real = torch.zeros((yn, xn), dtype=torch.float64, device=device)
     Z_imag = torch.zeros((yn, xn), dtype=torch.float64, device=device)
 
-    BLOCK_SIZE_X = 16
-    BLOCK_SIZE_Y = 16
-    grid = (triton.cdiv(xn, BLOCK_SIZE_X), triton.cdiv(yn, BLOCK_SIZE_Y))
+    grid = lambda meta: (
+        triton.cdiv(xn, meta['BLOCK_SIZE_X']),
+        triton.cdiv(yn, meta['BLOCK_SIZE_Y'])
+    )
 
 
     _kernel_mandelbrot[grid](
@@ -80,8 +90,6 @@ def mandelbrot(xmin, xmax, ymin, ymax, xn, yn, maxiter, horizon=2.0):
         yn,
         maxiter,
         horizon,
-        BLOCK_SIZE_X=BLOCK_SIZE_X,
-        BLOCK_SIZE_Y=BLOCK_SIZE_Y
     )
     Z = torch.complex(Z_real, Z_imag)
     return Z, N


### PR DESCRIPTION
This PR implements the `mandelbrot2` benchmark in Triton. It is very similar to `mandelbrot1`, except for the semantics of the output tensors:

- **mandelbrot1**: N: The number of iterations a point stayed inside the set. Z: The last Z value that was inside (or on) the horizon.
- **mandelbrot2**: N: The iteration number on which the point first diverged (it stores i + 1). Z: The first Z value that was outside the horizon.

The other implementations of this use a CPU-friendly approach that only continues computing points as long as they are inside the horizon. However, this does not map well to a GPU since every thread would have to know the new index of where to put its point in each iteration, requiring inter-thread communication. Instead, we just operate on all points and use masking.

This PR also adds autotuning to `mandelbrot1` since the code for it is identical.

## Benchmarks

```bash
$ python3 run_benchmark.py -b mandelbrot2 -f triton -p paper
***** Testing Triton with mandelbrot2 on the paper dataset, datatype default *****
NumPy - default - validation: 458ms
Triton - default - first/validation: 534ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 14ms
```

DaCe GPU does not complete:

```bash
***** Testing DaCe GPU with mandelbrot2 on the paper dataset, datatype default *****
NumPy - default - validation: 464ms
Exception Cannot create symbol "maxiter", the name is used by a data descriptor. raised while parsing DaCe program:
  in File "/home/rwohlbold/npbench/npbench/benchmarks/mandelbrot2/mandelbrot2_dace.py", line 102
    k += 1
Traceback (most recent call last):
  File "/home/rwohlbold/npbench/run_benchmark.py", line 63, in <module>
    test.run(args["preset"], args["validate"], args["repeat"], args["timeout"], datatype=args["datatype"])
  File "/home/rwohlbold/npbench/npbench/infrastructure/test.py", line 93, in run
    for impl, impl_name in self.frmwrk.implementations(self.bench):
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rwohlbold/npbench/npbench/infrastructure/dace_framework.py", line 90, in implementations
    base_sdfg, parse_time = util.benchmark("__npb_result = ct_impl.to_sdfg(simplify=False)",
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rwohlbold/npbench/npbench/infrastructure/utilities.py", line 138, in benchmark
    raw_time_list = timeit.repeat(stmt, setup=setup, repeat=repeat, number=1, globals=ldict)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/timeit.py", line 243, in repeat
    return Timer(stmt, setup, timer, globals).repeat(repeat, number)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/timeit.py", line 208, in repeat
    t = self.timeit(number)
        ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/timeit.py", line 180, in timeit
    timing = self.inner(it, self.timer)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<timeit-src>", line 6, in inner
  File "/usr/local/lib/python3.12/dist-packages/dace/frontend/python/parser.py", line 281, in to_sdfg
    sdfg = self._parse(args, kwargs, simplify=simplify, save=save, validate=validate)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/dace/frontend/python/parser.py", line 495, in _parse
    sdfg, cached = self._generate_pdp(args, kwargs, simplify=simplify)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/dace/frontend/python/parser.py", line 914, in _generate_pdp
    sdfg = newast.parse_dace_program(self.name,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/dace/frontend/python/newast.py", line 238, in parse_dace_program
    sdfg, _, _, _ = visitor.parse_program(preprocessed_ast.preprocessed_ast.body[0])
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/dace/frontend/python/newast.py", line 1234, in parse_program
    self.visit_TopLevel(stmt)
  File "/usr/local/lib/python3.12/dist-packages/dace/frontend/python/astutils.py", line 531, in visit_TopLevel
    return self.visit(node)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/dace/frontend/python/newast.py", line 1210, in visit
    return super().visit(node)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/ast.py", line 407, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/dace/frontend/python/newast.py", line 2502, in visit_While
    self.sdfg.add_symbol(astr, atom.dtype)
  File "/usr/local/lib/python3.12/dist-packages/dace/sdfg/sdfg.py", line 775, in add_symbol
    raise FileExistsError(f'Cannot create symbol "{name}", the name is used by a data descriptor.')
FileExistsError: Cannot create symbol "maxiter", the name is used by a data descriptor.
```