### PR TITLE
[polybench] Implement `floyd_warshall` in Triton

### DIFF
--- a/npbench/benchmarks/polybench/floyd_warshall/floyd_warshall_triton.py
+++ b/npbench/benchmarks/polybench/floyd_warshall/floyd_warshall_triton.py
@@ -1,0 +1,99 @@
+import triton
+import triton.language as tl
+
+from npbench.infrastructure.triton_utilities import get_2d_tile_offsets
+
+"""
+Triton implementation of:
+
+Katz, Gary J., and Joseph T. Kider. ‘All-Pairs Shortest-Paths for Large Graphs on the GPU’. 
+Proceedings of the 23rd ACM SIGGRAPH/EUROGRAPHICS Symposium on Graphics Hardware (Goslar, DEU), GH ’08, 
+Eurographics Association, 20 June 2008, 47–55.
+"""
+
+@triton.jit()
+def _mini_floyd(C, A, B, BLOCK_SIZE: tl.constexpr, a_may_alias_c: tl.constexpr = False,
+                b_may_alias_c: tl.constexpr = False):
+    for k in range(BLOCK_SIZE):
+        index = tl.full((BLOCK_SIZE, BLOCK_SIZE), k, dtype=tl.int32)
+        kth_column = tl.gather(A, index, axis=1)
+        kth_row = tl.gather(B, index, axis=0)
+        C = tl.minimum(C, kth_column + kth_row)
+        if a_may_alias_c:
+            A = C
+        if b_may_alias_c:
+            B = C
+    return C
+
+
+@triton.jit
+def _load_tile(path, x, y, BLOCK_SIZE: tl.constexpr, N: tl.constexpr):
+    tile, mask, rows, columns = get_2d_tile_offsets(x * BLOCK_SIZE, y * BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE, N, N)
+    other = tl.where(columns[None, :] == rows[:, None], 0, 999)
+    return tl.load(path + tile, mask, other=other), tile, mask
+
+
+@triton.jit(do_not_specialize=['k'])
+def _single_thread_part(path, k,
+                        N: tl.constexpr,
+                        BLOCK_SIZE: tl.constexpr):
+    w_kk, tile, mask = _load_tile(path, k, k, BLOCK_SIZE, N)
+    w_kk = _mini_floyd(w_kk, w_kk, w_kk, BLOCK_SIZE, True, True)
+    tl.store(path + tile, w_kk, mask)
+
+
+@triton.jit(do_not_specialize=['k'])
+def _1dim_thread_part(path, k,
+                      N: tl.constexpr,
+                      BLOCK_SIZE: tl.constexpr):
+    w_kk, tile, mask = _load_tile(path, k, k, BLOCK_SIZE, N)
+    j = tl.program_id(axis=1)
+
+    if j != k:
+        w_jk, tile, mask = _load_tile(path, k, j, BLOCK_SIZE, N)
+        w_jk = _mini_floyd(w_jk, w_jk, w_kk, BLOCK_SIZE, a_may_alias_c=True)
+        tl.store(path + tile, w_jk, mask)
+
+        w_kj, tile, mask = _load_tile(path, j, k, BLOCK_SIZE, N)
+        w_kj = _mini_floyd(w_kj, w_kk, w_kj, BLOCK_SIZE, b_may_alias_c=True)
+        tl.store(path + tile, w_kj, mask)
+
+
+@triton.jit(do_not_specialize=['k'])
+def _2dim_thread_part(path, k,
+                      N: tl.constexpr,
+                      BLOCK_SIZE: tl.constexpr):
+    i = tl.program_id(axis=0)
+    j = tl.program_id(axis=1)
+
+    if i != k or j != k:
+        w_ij, tile, mask = _load_tile(path, i, j, BLOCK_SIZE, N)
+        w_ik, _, _ = _load_tile(path, i, k, BLOCK_SIZE, N)
+        w_kj, _, _ = _load_tile(path, k, j, BLOCK_SIZE, N)
+        w_ij = _mini_floyd(w_ij, w_kj, w_ik, BLOCK_SIZE)
+        tl.store(path + tile, w_ij, mask)
+
+
+def kernel(path  # (N, N)
+           ):
+    """
+    for k in range(path.shape[0]):
+        for i in range(path.shape[0]):
+            for j in range(path.shape[0]):
+                path[i, j] = minimum(path[i, j], path[i, k] + path[k, j])
+    """
+
+    BLOCK_SIZE = 32
+    num_warps = 4
+
+    N = path.shape[0]
+    grid_1d = lambda meta: (triton.cdiv(N, meta['BLOCK_SIZE']),)
+    grid_2d = lambda meta: (triton.cdiv(N, meta['BLOCK_SIZE']), triton.cdiv(N, meta['BLOCK_SIZE']))
+
+    B = triton.cdiv(N, BLOCK_SIZE)
+    for k in range(0, B):
+        _single_thread_part[(1,)](path, k, N, BLOCK_SIZE, num_warps=num_warps)
+
+        _1dim_thread_part[grid_1d](path, k, N, BLOCK_SIZE, num_warps=num_warps)
+
+        _2dim_thread_part[grid_2d](path, k, N, BLOCK_SIZE, num_warps=num_warps)


### PR DESCRIPTION
This MR implements an efficient implementation of the `floyd_warshall` all shortest pair algorithm. It does so via a reimplementation of the algorithm made for CUDA and a blocking approach that we reimplemented in triton.

Due to memory dependencies and partially single threaded portions, we launch multiple kernels multiple times. I was unfortunately unable to implement a barrier version that did not deadlock. I therefore also had to perform manual autotuning as all block sizes of every kernel + the kernel launch loop must match.

We are currently 500 times faster than NumPy and about 12 times faster than DaCe.

```
***** Testing Triton with floyd_warshall on the paper dataset, datatype default *****
NumPy - default - validation: 42917ms
Triton - default - first/validation: 857ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 115ms
```

```
***** Testing DaCe GPU with floyd_warshall on the paper dataset, datatype default *****
NumPy - default - validation: 42642ms
DaCe GPU - fusion - first/validation: 2200ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 2196ms
DaCe GPU - parallel - first/validation: 2197ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 2195ms
DaCe GPU - auto_opt - first/validation: 1206ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 1368ms

```