### PR TITLE
add proper autotuning to kernels 

### DIFF
--- a/npbench/benchmarks/compute/compute_triton.py
+++ b/npbench/benchmarks/compute/compute_triton.py
@@ -4,19 +4,15 @@ import triton.language as tl
 import itertools
 import numpy as np
 
-def generate_config():
-    base = [
-        (64, 4, 3),
-        (128, 4, 3),
-        (32, 4, 3),
-        (128, 8, 4),  
+def get_configs():
+    return [
+        triton.Config({"BLOCK_SIZE_N": block_size}, num_warps=num_warps)
+        for block_size, num_warps in itertools.product(
+            [8, 16, 32, 64, 128], [1, 2, 4, 8]
+        )
     ]
-    return [triton.Config(
-                kwargs={"BLOCK_SIZE_N": n},
-                num_warps=w, num_stages=s)
-            for (n, w, s) in base]
 
-@triton.autotune(configs=generate_config(), key=["N"], cache_results=True)
+@triton.autotune(configs=get_configs(), key=["N"], cache_results=True)
 @triton.jit
 def _kernel(array_1, array_2, a, b, c, N, arr_out, DTYPE: tl.constexpr,
             BLOCK_SIZE_N : tl.constexpr):

--- a/npbench/benchmarks/go_fast/go_fast_triton.py
+++ b/npbench/benchmarks/go_fast/go_fast_triton.py
@@ -4,19 +4,15 @@ import triton.language as tl
 import itertools
 from triton.language.extra import libdevice
 
-def generate_config():
-    base = [
-        (64, 4, 3),
-        (128, 4, 3),
-        (32, 4, 3),
-        (128, 8, 4),  
+def get_configs():
+    return [
+        triton.Config({"BLOCK_SIZE_N": block_size}, num_warps=num_warps)
+        for block_size, num_warps in itertools.product(
+            [8, 16, 32, 64, 128], [1, 2, 4, 8]
+        )
     ]
-    return [triton.Config(
-                kwargs={"BLOCK_SIZE_N": n},
-                num_warps=w, num_stages=s)
-            for (n, w, s) in base]
 
-@triton.autotune(configs=generate_config(), key=["N"], cache_results=True)
+@triton.autotune(configs=get_configs(), key=["N"], cache_results=True)
 @triton.jit
 def _trace_of_matrix(A, N, trace, DTYPE: tl.constexpr,
             BLOCK_SIZE_N : tl.constexpr):
@@ -40,7 +36,7 @@ def _trace_of_matrix(A, N, trace, DTYPE: tl.constexpr,
     tl.atomic_add(trace, sum)
 
 
-@triton.autotune(configs=generate_config(), key=["N"], cache_results=True)
+@triton.autotune(configs=get_configs(), key=["N"], cache_results=True)
 @triton.jit
 def _add_trace_to_matrix(A, N, trace, DTYPE: tl.constexpr,
             BLOCK_SIZE_N : tl.constexpr):

--- a/npbench/benchmarks/polybench/doitgen/doitgen_triton.py
+++ b/npbench/benchmarks/polybench/doitgen/doitgen_triton.py
@@ -1,20 +1,17 @@
 # This kernel applies the matrix C4 to each
 import triton
 import triton.language as tl
+import itertools
 
-def generate_config():
-    base = [
-        (64, 4, 3),
-        (128, 4, 3),
-        (32, 4, 3),
-        (128, 8, 4),  
+def get_configs():
+    return [
+        triton.Config({"BLOCK_SIZE_P": block_size}, num_warps=num_warps)
+        for block_size, num_warps in itertools.product(
+            [8, 16, 32, 64, 128], [1, 2, 4, 8]
+        )
     ]
-    return [triton.Config(
-                kwargs={"BLOCK_SIZE_P": n},
-                num_warps=w, num_stages=s)
-            for (n, w, s) in base]
 
-@triton.autotune(configs=generate_config(), key=["NP"], cache_results=True)
+@triton.autotune(configs=get_configs(), key=["NP"], cache_results=True)
 @triton.jit
 def _kernel(
     NQ,


### PR DESCRIPTION
In some kernels, I realized that we don't do the "itertools" thing. I added it to all the currently merged kernels that did not have it. I managed really big speed ups on many of the kernels.

gemm --> 18 ms to 10 ms
doitgen --> 13 ms to 3 ms
trmm --> 23 ms to 6 ms
go_fast --> 5 ms to 2 ms