### PR TITLE
`durbin` kernel fix

### DIFF
--- a/npbench/benchmarks/polybench/durbin/durbin_triton.py
+++ b/npbench/benchmarks/polybench/durbin/durbin_triton.py
@@ -73,4 +73,4 @@ def kernel(r: torch.Tensor):
     y_temp = torch.empty_like(r)
 
     durbin_kernel[(1,)](y, y_temp, r, N)
-    return y.to(r.dtype)
+    return y


### PR DESCRIPTION
This is a faster version of Durbin. Review code tomorrow to find out more

Edit (Josh):

```/usr/bin/python3 /home/jfreeman/npbench/run_benchmark.py -p paper -f triton -b durbin 
/usr/local/lib/python3.12/dist-packages/pandas/core/arrays/masked.py:61: UserWarning: Pandas requires version '1.3.6' or newer of 'bottleneck' (version '1.3.5' currently installed).
  from pandas.core import (
***** Testing Triton with durbin on the paper dataset, datatype default *****
NumPy - default - validation: 755ms
Triton - default - first/validation: 141606ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 388ms
```