### PR TITLE
[npbench] Fix validation logic for cases where framework does not return enough outputs

### DIFF
--- a/npbench/infrastructure/test.py
+++ b/npbench/infrastructure/test.py
@@ -122,8 +122,9 @@ class Test(object):
                         print("{} - {} - validation: SUCCESS".format(frmwrk_name, impl_name))
                     elif not ignore_errors:
                         raise ValueError("{} did not validate!".format(frmwrk_name))
-                except Exception:
+                except Exception as e:
                     print("Failed to run {} validation.".format(self.frmwrk.info["full_name"]))
+                    traceback.print_exception(e)
                     if not ignore_errors:
                         raise
             # Main execution

--- a/npbench/infrastructure/utilities.py
+++ b/npbench/infrastructure/utilities.py
@@ -152,11 +152,15 @@ def benchmark(stmt, setup="pass", out_text="", repeat=1, context={}, output=None
 
 
 def validate(ref, val, framework="Unknown", rtol=1e-5, atol=1e-8, norm_error=1e-5):
+    valid = True
     if not isinstance(ref, (tuple, list)):
         ref = [ref]
     if not isinstance(val, (tuple, list)):
         val = [val]
-    valid = True
+    # We do this check instead of strict=True in zip to give a more informative error message
+    if len(ref) > len(val):
+        print(f"{framework} did not return enough elements. Maybe you forgot a return statement?")
+        valid = False
     for r, v in zip(ref, val):
         if f"{type(v).__module__}.{type(v).__name__}" == "torch.Tensor":
             v = v.cpu().numpy()


### PR DESCRIPTION
In NPBench, after running a benchmark, a list of outputs is constructed. This contains the return values of the benchmark implementation as well as any input arguments listed in the `output_args` configuration key of the benchmark.
However, the validation function uses `zip` to iterate over pairs of outputs returned by NumPy (reference) and the framework implementation.

In a case where the arguments to `zip` don't have the same length, the framework will not validate the remaining elements of the larger list.

In particular, if a kernel has no `output_args`, this makes a kernel returning `None` pass (example for `durbin`):

```python
def kernel(r):
    pass
```

With the improved validation logic, the kernels `go_fast` and `durbin` sadly don't pass anymore.