### PR TITLE
Implement `channel_flow` kernel in Triton

### DIFF
--- a/npbench/benchmarks/channel_flow/channel_flow.py
+++ b/npbench/benchmarks/channel_flow/channel_flow.py
@@ -7,7 +7,7 @@ def initialize(ny, nx, datatype=np.float32):
     u = np.zeros((ny, nx), dtype=datatype)
     v = np.zeros((ny, nx), dtype=datatype)
     p = np.ones((ny, nx), dtype=datatype)
-    dx = 2 / (nx - 1)
-    dy = 2 / (ny - 1)
-    dt = .1 / ((nx - 1) * (ny - 1))
+    dx = datatype(2 / (nx - 1))
+    dy = datatype(2 / (ny - 1))
+    dt = datatype(.1 / ((nx - 1) * (ny - 1)))
     return u, v, p, dx, dy, dt

--- a/npbench/benchmarks/channel_flow/channel_flow_triton.py
+++ b/npbench/benchmarks/channel_flow/channel_flow_triton.py
@@ -239,17 +239,17 @@ def channel_flow(nit, u, v, dt, dx, dy, p, rho, nu, F):
     sum_u_curr = torch.sum(u_curr)
 
     while udiff > 0.001:
-        build_b_kernel[grid](u_curr, v_curr, b_dev, rho, dt, dx, dy, H, W)
+        build_b_kernel[grid](u_curr, v_curr, b_dev, float(rho), float(dt), float(dx), float(dy), H, W)
 
         p_in, p_out = p_curr, p_next
         for _ in range(nit):
-            pressure_poisson_kernel[grid](p_out, p_in, b_dev, dx, dy, H, W)
+            pressure_poisson_kernel[grid](p_out, p_in, b_dev, float(dx), float(dy), H, W)
             p_in, p_out = p_out, p_in  # Swap
 
         p_curr, p_next = p_in, p_out
 
         update_uv_kernel[grid](
-            u_next, v_next, u_curr, v_curr, p_curr, rho, nu, dt, dx, dy, F, H, W
+            u_next, v_next, u_curr, v_curr, p_curr, float(rho), float(nu), float(dt), float(dx), float(dy), float(F), H, W
         )
 
         sum_u_next = torch.sum(u_next)


### PR DESCRIPTION
This PR implements the `channel_flow` kernel.

## Benchmarks

### DaCe (other PR that fixes the implementation)

```
$ python3 run_benchmark.py -p S -v True -f dace_gpu -b channel_flow -p paper 
***** Testing DaCe GPU with channel_flow on the paper dataset, datatype default *****
NumPy - default - validation: 5554ms
DaCe GPU - fusion - first/validation: 1268ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 1272ms
DaCe GPU - parallel - first/validation: 1270ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 1272ms
DaCe GPU - auto_opt - first/validation: 1153ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 1153ms
```

### Triton

```
$ python3 run_benchmark.py -p S -v True -f triton -b channel_flow -p paper 
***** Testing Triton with channel_flow on the paper dataset, datatype default *****
NumPy - default - validation: 5532ms
Triton - default - first/validation: 3265ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 6ms
```