### PR TITLE
Convert `contour_integral` to run on float32

### DIFF
--- a/npbench/benchmarks/contour_integral/contour_integral.py
+++ b/npbench/benchmarks/contour_integral/contour_integral.py
@@ -3,14 +3,14 @@
 import numpy as np
 
 
-def rng_complex(shape, rng):
-    return (rng.random(shape) + rng.random(shape) * 1j)
+def rng_complex(shape, rng, datatype):
+    return (rng.random(shape, dtype=datatype) + rng.random(shape, dtype=datatype) * 1j)
 
 
-def initialize(NR, NM, slab_per_bc, num_int_pts, datatype=np.float64):
+def initialize(NR, NM, slab_per_bc, num_int_pts, datatype=np.float32):
     from numpy.random import default_rng
     rng = default_rng(42)
-    Ham = rng_complex((slab_per_bc + 1, NR, NR), rng)
-    int_pts = rng_complex((num_int_pts, ), rng)
-    Y = rng_complex((NR, NM), rng)
+    Ham = rng_complex((slab_per_bc + 1, NR, NR), rng, datatype)
+    int_pts = rng_complex((num_int_pts, ), rng, datatype)
+    Y = rng_complex((NR, NM), rng, datatype)
     return Ham, int_pts, Y

--- a/npbench/benchmarks/contour_integral/contour_integral_dace.py
+++ b/npbench/benchmarks/contour_integral/contour_integral_dace.py
@@ -3,18 +3,20 @@
 import numpy as np
 import dace as dc
 
+from npbench.infrastructure.dace_framework import dc_complex_float
+
 NR, NM, slab_per_bc = (dc.symbol(s, dtype=dc.int64)
                        for s in ('NR', 'NM', 'slab_per_bc'))
 
 
 @dc.program
-def contour_integral(Ham: dc.complex128[slab_per_bc + 1, NR, NR],
-                     int_pts: dc.complex128[32], Y: dc.complex128[NR, NM]):
-    P0 = np.zeros((NR, NM), dtype=np.complex128)
-    P1 = np.zeros((NR, NM), dtype=np.complex128)
+def contour_integral(Ham: dc_complex_float[slab_per_bc + 1, NR, NR],
+                     int_pts: dc_complex_float[32], Y: dc_complex_float[NR, NM]):
+    P0 = np.zeros((NR, NM), dtype=dc_complex_float)
+    P1 = np.zeros((NR, NM), dtype=dc_complex_float)
     for idx in range(32):
         z = int_pts[idx]
-        Tz = np.zeros((NR, NR), dtype=np.complex128)
+        Tz = np.zeros((NR, NR), dtype=dc_complex_float)
         for n in range(slab_per_bc + 1):
             zz = np.power(z, slab_per_bc / 2 - n)
             Tz += zz * Ham[n]

--- a/npbench/infrastructure/dace_framework.py
+++ b/npbench/infrastructure/dace_framework.py
@@ -7,6 +7,7 @@ from npbench.infrastructure import Benchmark, Framework, utilities as util
 from typing import Callable, Literal, Sequence, Tuple, Union
 
 dc_float = None
+dc_complex_float = None
 
 class DaceFramework(Framework):
     """ A class for reading and processing framework information. """
@@ -319,6 +320,7 @@ class DaceFramework(Framework):
     def set_datatype(self, datatype: Union[Literal['float32'], Literal['float64'], None]):
         # We might get None here if no datatype is specified. This is sad since we cannot know the exact datatype here
         # and we are relying on the fact that frameworks have their default datatypes set to float32.
-        global dc_float
-        from dace import float32, float64
+        global dc_float, dc_complex_float
+        from dace import float32, float64, complex64, complex128
         dc_float = float64 if datatype == 'float64' else float32
+        dc_complex_float = complex128 if datatype == 'float64' else complex64


### PR DESCRIPTION
Tiny PR that makes `contour_integral` also run with `float32`. Since it operates on complex numbers, we map float32 to complex64 and float64 to complex128. The corresponding DaCe kernel has also been updated. Note it has a large validation errors, but these are pre-existing