### PR TITLE
Implement `scattering_self_energies` in Triton

### DIFF
--- a/npbench/benchmarks/scattering_self_energies/scattering_self_energies.py
+++ b/npbench/benchmarks/scattering_self_energies/scattering_self_energies.py
@@ -3,20 +3,20 @@
 import numpy as np
 
 
-def rng_complex(shape, rng):
-    return (rng.random(shape) + rng.random(shape) * 1j)
+def rng_complex(shape, rng, datatype):
+    return (rng.random(shape, dtype=datatype) + rng.random(shape, dtype=datatype) * 1j)
 
 
-def initialize(Nkz, NE, Nqz, Nw, N3D, NA, NB, Norb):
+def initialize(Nkz, NE, Nqz, Nw, N3D, NA, NB, Norb, datatype=np.float32):
     from numpy.random import default_rng
     rng = default_rng(42)
 
     neigh_idx = np.ndarray([NA, NB], dtype=np.int32)
     for i in range(NA):
         neigh_idx[i] = np.positive(np.arange(i - NB / 2, i + NB / 2) % NA)
-    dH = rng_complex([NA, NB, N3D, Norb, Norb], rng)
-    G = rng_complex([Nkz, NE, NA, Norb, Norb], rng)
-    D = rng_complex([Nqz, Nw, NA, NB, N3D, N3D], rng)
-    Sigma = np.zeros([Nkz, NE, NA, Norb, Norb], dtype=np.complex128)
+    dH = rng_complex([NA, NB, N3D, Norb, Norb], rng, datatype)
+    G = rng_complex([Nkz, NE, NA, Norb, Norb], rng, datatype)
+    D = rng_complex([Nqz, Nw, NA, NB, N3D, N3D], rng, datatype)
+    Sigma = np.zeros([Nkz, NE, NA, Norb, Norb], dtype=D.dtype)
 
     return neigh_idx, dH, G, D, Sigma

--- a/npbench/benchmarks/scattering_self_energies/scattering_self_energies_triton.py
+++ b/npbench/benchmarks/scattering_self_energies/scattering_self_energies_triton.py
@@ -1,0 +1,100 @@
+import torch
+import triton
+import triton.language as tl
+
+from npbench.infrastructure.triton_utilities import derive_launch_arguments, get_2d_tile_offsets, get_6d_tile_offsets, \
+    complex_matmul2, complex_mul2, use_grid
+
+
+@use_grid(lambda meta: (meta['NA'], meta['Nkz']))
+@derive_launch_arguments(lambda dH, G, D, **_: {
+    'NA': dH.shape[0],
+    'NB': dH.shape[1],
+    'NE': G.shape[1],
+    'N3D': dH.shape[2],
+    'Norb': dH.shape[3],
+    'Nkz': G.shape[0],
+    'Nqz': D.shape[0],
+    'Nw': D.shape[1],
+    'BLOCK_NORB': triton.next_power_of_2(dH.shape[3]),
+})
+@triton.autotune(configs=[triton.Config(kwargs={}, num_warps=w) for w in [1, 2, 4, 8, 16]],
+                 key=['NA', 'NB', 'NE', 'N3D', 'Norb', 'Nkz', 'Nqz', 'Nw'], cache_results=True)
+@triton.jit
+def _kernel(
+        neigh_idx,  # (NA, NB)[int32]
+        dH,  # (NA, NB, N3D, Norb, Norb, 2)
+        G,  # (Nkz, NE, NA, Norb, Norb, 2)
+        D,  # (Nqz, Nw, NA, NB, N3D, N3D, 2)
+        Sigma,  # (Nkz, NE, NA, Norb, Norb, 2) (zero-init.)
+        NA: tl.constexpr,
+        NB: tl.constexpr,
+        N3D: tl.constexpr,
+        Norb: tl.constexpr,
+        Nkz: tl.constexpr,
+        NE: tl.constexpr,
+        Nqz: tl.constexpr,
+        Nw: tl.constexpr,
+        BLOCK_NORB: tl.constexpr,
+):
+    a = tl.program_id(axis=0)
+    k = tl.program_id(axis=1)
+
+    # Note: Parallelizing over E would be a potentially bad idea as the task lengths would be unequal due to the 'w'
+    # loop running different number of times.
+    for E in range(NE):  # |10|
+        acc = tl.zeros((1, 1, 1, BLOCK_NORB, BLOCK_NORB, 2), dtype=G.dtype.element_ty)
+
+        for q in range(Nqz):  # |4|
+            for w in range(tl.minimum(Nw, E)):  # max |3|
+                for b in range(NB):  # |4|
+                    tile, mask, _, _ = get_2d_tile_offsets(b, a,
+                                                           tile_width=1, tile_height=1,
+                                                           matrix_width=NB,
+                                                           matrix_height=NA)
+                    index = tl.load(neigh_idx + tile, mask)
+                    index = tl.reshape(index, (1,))
+                    tile, mask = get_6d_tile_offsets(k, E - w, index, 0, 0, 0,
+                                                     tile_dims=(1, 1, 1, BLOCK_NORB, BLOCK_NORB, 2),
+                                                     matrix_dims=(Nkz, NE, NA, Norb, Norb, 2))
+                    g_tile = tl.load(G + tile, mask, other=0.0)
+
+                    for i in range(N3D):  # |3|
+                        tile, mask = get_6d_tile_offsets(a, b, i, 0, 0, 0,
+                                                         tile_dims=(1, 1, 1, BLOCK_NORB, BLOCK_NORB, 2),
+                                                         matrix_dims=(NA, NB, N3D, Norb, Norb, 2))
+                        dH_tile = tl.load(dH + tile, mask, other=0.0)
+                        dHG = complex_matmul2(g_tile, dH_tile)
+
+                        for j in range(N3D):  # |3|
+                            tile, mask = get_6d_tile_offsets(a, b, j, 0, 0, 0,
+                                                             tile_dims=(1, 1, 1, BLOCK_NORB, BLOCK_NORB, 2),
+                                                             matrix_dims=(NA, NB, N3D, Norb, Norb, 2))
+                            dH_tile = tl.load(dH + tile, mask, other=0.0)  # (BLOCK_NORB, BLOCK_NORB, 2)
+
+                            D_offset = D + get_6d_tile_offsets(q, w, a, b, i, j,
+                                                               tile_dims=(1, 1, 1, 1, 1, 2),
+                                                               matrix_dims=(Nqz, Nw, NA, NB, N3D, N3D, 2))[0]
+                            D_tile = tl.load(D_offset)  # (1, 1, 1, 1, 1, 2)
+                            D_tile = tl.broadcast_to(D_tile, dH_tile.shape)
+
+                            dHD = complex_mul2(dH_tile, D_tile)
+                            acc += complex_matmul2(dHG, dHD)
+
+        tile, mask = get_6d_tile_offsets(k, E, a, 0, 0, 0,
+                                         tile_dims=(1, 1, 1, BLOCK_NORB, BLOCK_NORB, 2),
+                                         matrix_dims=(Nkz, NE, NA, Norb, Norb, 2))
+        tl.store(Sigma + tile, acc, mask)
+
+
+def scattering_self_energies(neigh_idx,  # (NA, NB)[int32]
+                             dH,  # (NA, NB, N3D, Norb, Norb)[complex]
+                             G,  # (Nkz, NE, NA, Norb, Norb)[complex]
+                             D,  # (Nqz, Nw, NA, NB, N3D, N3D)[complex]
+                             Sigma,  # (Nkz, NE, NA, Norb, Norb)[complex] (zero-init.)
+                             ):
+    _kernel(neigh_idx,
+            torch.view_as_real(dH),
+            torch.view_as_real(G),
+            torch.view_as_real(D),
+            torch.view_as_real(Sigma))


### PR DESCRIPTION
This is one of the weirdest kernel by far. I mostly reimplemented it line for line in Triton only changing:
* the loop ordering
* parallelizing the `a` and `k` loops

There is no tiling happening beyond what the numpy implementation does as well, yet we are achieving crazy performance. I suspect this to be due to how incredibly slow the python loops are in the other frameworks. Nsight compute claims we have 25% occupancy, i.e. in theory it could be 4 times faster, but we are already at 1 ms.

DaCe and CuPy performance are disastrous.

```
***** Testing Triton with scattering_self_energies on the paper dataset, datatype default *****
NumPy - default - validation: 1866ms
Triton - default - first/validation: 735ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 1ms

***** Testing CuPy with scattering_self_energies on the paper dataset, datatype default *****
NumPy - default - validation: 1792ms
CuPy - default - first/validation: 42284ms
CuPy - default - default - validation: SUCCESS
CuPy - default - median: 40799ms

***** Testing DaCe GPU with scattering_self_energies on the paper dataset, datatype default *****
NumPy - default - validation: 1803ms
DaCe GPU - fusion - first/validation: 20905ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 16666ms
DaCe GPU - parallel - first/validation: 16784ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 16701ms
DaCe GPU - auto_opt - first/validation: 13503ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 13425ms
```

Depends on `contour_integral` implementation.