### PR TITLE
implement `nbody` kernel

### DIFF
--- a/npbench/benchmarks/nbody/nbody_triton.py
+++ b/npbench/benchmarks/nbody/nbody_triton.py
@@ -3,7 +3,6 @@ import triton
 import triton.language as tl
 import itertools
 from triton.language.extra import libdevice
-from npbench.infrastructure.triton_utilities import kernel_mean
 
 def get_configs():
     return [
@@ -269,4 +268,4 @@ def nbody(mass, pos, vel, N, Nt, dt, G, softening):
         KE[i + 1] = 0.5 * torch.sum(mass * vel**2)
         PE[i + 1] = pe_acc[0]
 
-    return KE.cpu().numpy(), PE.cpu().numpy()
+    return KE, PE


### PR DESCRIPTION
No matter what I did, I could not get the relative error lower :( The norm_error in the json file is 1e-1 so I am super close... But note that it has super similar validation error as CuPy (also doesn't validate).

As per, DaCe GPU does not validate.

```
python3 npbench/run_benchmark.py -b nbody -f triton -p paper -v True
***** Testing Triton with nbody on the paper dataset, datatype default *****
NumPy - default - validation: 645ms
Triton - default - first/validation: 13596ms
Relative error: 0.11916907876729965
Triton - default did not validate!
Triton - default - median: 306ms

python3 npbench/run_benchmark.py -b nbody -f cupy -p paper -v True
***** Testing CuPy with nbody on the paper dataset, datatype default *****
NumPy - default - validation: 696ms
CuPy - default - first/validation: 4918ms
Relative error: 0.11783427271554262
CuPy - default did not validate!
CuPy - default - median: 1722ms

python3 npbench/run_benchmark.py -b nbody -f dace_gpu -p paper -v True
***** Testing DaCe GPU with nbody on the paper dataset, datatype default *****
NumPy - default - validation: 478ms
DaCe GPU - fusion - first/validation: 40879ms
Relative error: 1.0
Relative error: nan
DaCe GPU - fusion did not validate!
```

Validation Issue filed: https://github.com/zero9178/npbench/issues/77
