### PR TITLE
feat: implementation of `vadv` kernel

### DIFF
--- a/npbench/benchmarks/weather_stencils/vadv/vadv_triton.py
+++ b/npbench/benchmarks/weather_stencils/vadv/vadv_triton.py
@@ -5,8 +5,7 @@ import torch
 
 @triton.autotune(
     configs=[
-        triton.Config({"BLOCK_SIZE": bs}, num_warps=nw)
-        for bs in [64, 128, 256, 512]
+        triton.Config({}, num_warps=nw)
         for nw in [1, 2, 4, 8]
     ],
     key=["I", "J", "K"],
@@ -23,7 +22,6 @@ def vadv_kernel(
     data_col_ptr,
     dtr_stage,
     I, J, K,
-    BLOCK_SIZE: tl.constexpr,
 ):
     ij_idx = tl.program_id(0)
     i = ij_idx // J


### PR DESCRIPTION
# Description
This PR implements my last kernel, `vadv`. This passes all datasets with float64 but only some on float32. See issue [85](https://github.com/zero9178/npbench/issues/85).

# Test plan
```
jfreeman@joshua-X570-AORUS-ELITE:~/dhcp/npbench-hpc-fork$ rm -rf ~/.triton/cache/* && /usr/bin/python3 run_benchmark.py -p paper -f dace_gpu -b vadv
***** Testing DaCe GPU with vadv on the paper dataset, datatype default *****
NumPy - default - validation: 879ms
DaCe GPU - fusion - first/validation: 103ms
Relative error: 7.538953650509939e-05
DaCe GPU - fusion did not validate!
DaCe GPU - fusion - median: 98ms
DaCe GPU - parallel - first/validation: 97ms
Relative error: 7.538953650509939e-05
DaCe GPU - parallel did not validate!
DaCe GPU - parallel - median: 97ms
DaCe GPU - auto_opt - first/validation: 107ms
Relative error: 7.538953650509939e-05
DaCe GPU - auto_opt did not validate!
DaCe GPU - auto_opt - median: 106ms
jfreeman@joshua-X570-AORUS-ELITE:~/dhcp/npbench-hpc-fork$ rm -rf ~/.triton/cache/* && /usr/bin/python3 run_benchmark.py -p paper -f triton -b vadv
***** Testing Triton with vadv on the paper dataset, datatype default *****
NumPy - default - validation: 877ms
Triton - default - first/validation: 7614ms
Relative error: 7.538463978562504e-05
Triton - default did not validate!
Triton - default - median: 8ms
jfreeman@joshua-X570-AORUS-ELITE:~/dhcp/npbench-hpc-fork$ rm -rf ~/.triton/cache/* && /usr/bin/python3 run_benchmark.py -p paper -f triton -b vadv -d float64
***** Testing Triton with vadv on the paper dataset, datatype float64 *****
NumPy - default - validation: 1184ms
Triton - default - first/validation: 45853ms
Triton - default - default - validation: SUCCESS
Triton - default - median: 94ms
jfreeman@joshua-X570-AORUS-ELITE:~/dhcp/npbench-hpc-fork$ rm -rf ~/.triton/cache/* && /usr/bin/python3 run_benchmark.py -p paper -f dace_gpu -b vadv -d float64
***** Testing DaCe GPU with vadv on the paper dataset, datatype float64 *****
NumPy - default - validation: 1188ms
DaCe GPU - fusion - first/validation: 142ms
DaCe GPU - fusion - fusion - validation: SUCCESS
DaCe GPU - fusion - median: 137ms
DaCe GPU - parallel - first/validation: 138ms
DaCe GPU - parallel - parallel - validation: SUCCESS
DaCe GPU - parallel - median: 138ms
DaCe GPU - auto_opt - first/validation: 122ms
DaCe GPU - auto_opt - auto_opt - validation: SUCCESS
DaCe GPU - auto_opt - median: 122ms
```